### PR TITLE
Mention uBlock Origin in the injected script

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -572,7 +572,7 @@ if ( !abort ) {
         return new RegExp('(^|\.)(' + aa.map(restrFromString).join('|') + ')$');
     };
 
-    var scriptText = [], entry, re;
+    var scriptText = ['/* uBlock Origin Extra */'], entry, re;
 
     while ( (entry = scriptlets.shift()) ) {
         if ( Array.isArray(entry.targets) ) {


### PR DESCRIPTION
I spent a nontrivial amount of time working out what was injecting suspicious-looking scripts into my pages; mentioning uBO-Extra in a comment would have avoided that.